### PR TITLE
Validate task config before starting task.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added CHANGELOG to project.
   - Support for command execution inside tasks. `nomad alloc exec` is now
     working in containers started with the `boot` parameter.
+  - Validate configuration before trying to start a task. The driver will
+    not try to start tasks with invalid configuration.
 ### Changed
   - Naming of started containers now matches the schema of the docker driver
     `<task-name>-<allocID>`.

--- a/nspawn/driver.go
+++ b/nspawn/driver.go
@@ -266,8 +266,6 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 		return nil, nil, fmt.Errorf("failed to decode driver config: %v", err)
 	}
 
-	d.logger.Info("starting nspawn task", "driver_cfg", hclog.Fmt("%+v", driverConfig))
-	d.logger.Debug("resources", "nomad", fmt.Sprintf("%+v", cfg.Resources.NomadResources), "linux", fmt.Sprintf("%+v", cfg.Resources.LinuxResources))
 	handle := drivers.NewTaskHandle(taskHandleVersion)
 	handle.Config = cfg
 
@@ -328,12 +326,18 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 
 	}
 
+	if err := driverConfig.Validate(); err != nil {
+		return nil, nil, fmt.Errorf("failed to validate task config: %v", err)
+	}
+
 	args, err := driverConfig.ConfigArray()
 	if err != nil {
 		d.logger.Error("Error generating machine config", "error", err)
 		return nil, nil, err
 	}
 
+	d.logger.Info("starting nspawn task", "driver_cfg", hclog.Fmt("%+v", driverConfig))
+	d.logger.Debug("resources", "nomad", fmt.Sprintf("%+v", cfg.Resources.NomadResources), "linux", fmt.Sprintf("%+v", cfg.Resources.LinuxResources))
 	d.logger.Info("commad arguments", "args", args)
 
 	cmd := exec.Command("systemd-nspawn", args...)


### PR DESCRIPTION
To avoid silent failures of systemd-nspawn, we validate the passed task
configuration before trying to start it.