### PR TITLE
Bridge mode support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+  - Support for Nomad `bridge` networking mode. This also enables the use of
+    Consul Connect.
 ## [0.2.0] - 2020-06-27
 ### Added
   - Support for downloading images via the

--- a/example/README.md
+++ b/example/README.md
@@ -48,3 +48,10 @@ simply execute:
 ```shell
 $ nomad run debian.hcl
 ```
+
+## bridge-mode
+
+This folder contains the same job as the `Nginx` folder but configured to run in
+`bridge` network mode. Make sure to have a look at the [Nomad Consul Connect
+example](https://www.nomadproject.io/docs/integrations/consul-connect#prerequisites)
+and install all necessary prerequisites before running this job.

--- a/example/README.md
+++ b/example/README.md
@@ -55,3 +55,65 @@ This folder contains the same job as the `Nginx` folder but configured to run in
 `bridge` network mode. Make sure to have a look at the [Nomad Consul Connect
 example](https://www.nomadproject.io/docs/integrations/consul-connect#prerequisites)
 and install all necessary prerequisites before running this job.
+
+## consul-connect
+
+This folder contains yet another variant of the `Nginx` job. This time, bridge
+mode is enabled and a `consul-connect` sidecar proxy is registered for the
+service. To run this job, make sure you followed the tutorial linked above. Then
+start Nomad with Consul connect enabled.
+
+```shell
+$ sudo nomad agent -dev-connect
+```
+
+Open another terminal window and also start Consul
+
+```shell
+$ sudo consul -agent -dev
+```
+
+In a third terminal window you can now start the Nomad job via 
+
+```shell
+$ nomad run nginx.hcl
+```
+
+If you want to connect to the service, you will need to start a local Consul
+connect proxy.
+
+```shell
+$ consul connect proxy -upstream 'consul-connect-bridge:8082' -service proxy
+```
+
+Then you can access the service in a fourth terminal window by connecting to the
+proxy.
+
+```shell
+$ curl http://127.0.0.1:8082
+<!DOCTYPE html>
+<html>
+<head>
+<title>Welcome to nginx!</title>
+<style>
+    body {
+        width: 35em;
+        margin: 0 auto;
+        font-family: Tahoma, Verdana, Arial, sans-serif;
+    }
+</style>
+</head>
+<body>
+<h1>Welcome to nginx!</h1>
+<p>If you see this page, the nginx web server is successfully installed and
+working. Further configuration is required.</p>
+
+<p>For online documentation and support please refer to
+<a href="http://nginx.org/">nginx.org</a>.<br/>
+Commercial support is available at
+<a href="http://nginx.com/">nginx.com</a>.</p>
+
+<p><em>Thank you for using nginx.</em></p>
+</body>
+</html>
+```

--- a/example/bridge-mode/mkosi.default
+++ b/example/bridge-mode/mkosi.default
@@ -1,0 +1,12 @@
+[Distribution]
+Distribution=debian
+Release=stable
+
+[Output]
+Format=directory
+
+[Validation]
+Password=root
+
+[Packages]
+Packages=nginx,iproute2,isc-dhcp-client

--- a/example/bridge-mode/mkosi.postinst
+++ b/example/bridge-mode/mkosi.postinst
@@ -1,0 +1,10 @@
+#!/bin/sh
+systemctl enable systemd-resolved
+systemctl enable systemd-networkd
+{
+  echo "pts/0"
+  echo "pts/1"
+  echo "pts/2"
+  echo "pts/3"
+  echo "pts/4"
+} >> /etc/securetty

--- a/example/bridge-mode/nginx.hcl
+++ b/example/bridge-mode/nginx.hcl
@@ -1,0 +1,38 @@
+job "bridge-mode" {
+  datacenters = ["dc1"]
+  type = "service"
+  group "bridge" {
+    count = 1
+    task "nginx" {
+      driver = "nspawn"
+      config {
+        image = "example/bridge-mode/image"
+        resolv_conf = "copy-host"
+        command = ["/bin/bash", "-c", "dhclient && nginx && tail -f /var/log/nginx/access.log " ]
+        boot = false
+        process_two = true
+      }
+    }
+    network {
+      port "http" {
+        static = 8081
+        to = 80
+      }
+      mode = "bridge"
+    }
+    service {
+      tags = ["nginx"]
+      port = "http"
+      address_mode = "host"
+
+      check {
+        type = "http"
+        port = "http"
+        path = "/"
+        interval = "10s"
+        timeout = "5s"
+        address_mode = "driver"
+      }
+    }
+  }
+}

--- a/example/consul-connect/mkosi.default
+++ b/example/consul-connect/mkosi.default
@@ -1,0 +1,12 @@
+[Distribution]
+Distribution=debian
+Release=stable
+
+[Output]
+Format=directory
+
+[Validation]
+Password=root
+
+[Packages]
+Packages=nginx,iproute2,isc-dhcp-client

--- a/example/consul-connect/mkosi.postinst
+++ b/example/consul-connect/mkosi.postinst
@@ -1,0 +1,10 @@
+#!/bin/sh
+systemctl enable systemd-resolved
+systemctl enable systemd-networkd
+{
+  echo "pts/0"
+  echo "pts/1"
+  echo "pts/2"
+  echo "pts/3"
+  echo "pts/4"
+} >> /etc/securetty

--- a/example/consul-connect/nginx.hcl
+++ b/example/consul-connect/nginx.hcl
@@ -1,0 +1,28 @@
+job "consul-connect" {
+  datacenters = ["dc1"]
+  type = "service"
+  group "bridge" {
+    count = 1
+    task "nginx" {
+      driver = "nspawn"
+      config {
+        image = "example/consul-connect/image"
+        resolv_conf = "copy-host"
+        command = ["/bin/bash", "-c", "dhclient && nginx && tail -f /var/log/nginx/access.log " ]
+        boot = false
+        process_two = true
+      }
+    }
+    network {
+      mode = "bridge"
+    }
+    service {
+      tags = ["nginx", "connect"]
+      port = "80"
+
+      connect {
+        sidecar_service {}
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds support for the Nomad `bridge` network mode. It thereby also
enables the use of Consul Connect with the `nspawn` driver.

For an example how to use it, have a look at the `example/bridge-mode` and
`example/consul-connect` folders.
