### PR TITLE
Print error if systemd-nspawn fails to start a task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
   - Support for Nomad `bridge` networking mode. This also enables the use of
     Consul Connect.
+  - Output the error why systemd-nspawn fails on startup. It is added to the
+    logs and shown in the WebUi.
 ## [0.2.0] - 2020-06-27
 ### Added
   - Support for downloading images via the


### PR DESCRIPTION
If systemd-nspawn fails to start a task/container, parse the generated log lines
and print the last lines of stdout and stderr to aid debugging.

This closes #9 