### PR TITLE
Add `capability` option and allow all values for `resolve_conf`

### DIFF
--- a/nspawn/driver.go
+++ b/nspawn/driver.go
@@ -107,6 +107,7 @@ var (
 		"bind_read_only":    hclspec.NewAttr("bind_read_only", "list(map(string))", false),
 		"environment":       hclspec.NewAttr("environment", "list(map(string))", false),
 		"port_map":          hclspec.NewAttr("port_map", "list(map(number))", false),
+		"capability":        hclspec.NewAttr("capability", "list(string)", false),
 	})
 
 	// capabilities is returned by the Capabilities RPC and indicates what

--- a/nspawn/nspawn.go
+++ b/nspawn/nspawn.go
@@ -54,6 +54,7 @@ type MachineConfig struct {
 	Bind             hclutils.MapStrStr `codec:"bind"`
 	BindReadOnly     hclutils.MapStrStr `codec:"bind_read_only"`
 	Boot             bool               `codec:"boot"`
+	Capability       []string           `codec:"capability"`
 	Command          []string           `codec:"command"`
 	Console          string             `codec:"console"`
 	Environment      hclutils.MapStrStr `codec:"environment"`
@@ -173,6 +174,9 @@ func (c *MachineConfig) ConfigArray() ([]string, error) {
 	}
 	if len(c.Command) > 0 {
 		args = append(args, c.Command...)
+	}
+	if len(c.Capability) > 0 {
+		args = append(args, "--capability", strings.Join(c.Capability, ","))
 	}
 	return args, nil
 }

--- a/nspawn/nspawn.go
+++ b/nspawn/nspawn.go
@@ -198,8 +198,9 @@ func (c *MachineConfig) Validate() error {
 	}
 	if c.ResolvConf != "" {
 		switch c.ResolvConf {
-		case "copy-host", "copy-static", "bind-host",
-			"bind-static", "delete", "auto":
+		case "off", "copy-host", "copy-static", "copy-uplink", "copy-stub",
+			"replace-host", "replace-static", "replace-uplink", "replace-stub",
+			"bind-host", "bind-static", "bind-uplink", "bind-stub", "delete", "auto":
 		default:
 			return fmt.Errorf("invalid parameter for resolv_conf")
 		}


### PR DESCRIPTION
This small PR adds two things:
  * ability to pass capabilities,
  * allow to specify all `resolve_conf` values [supported by systemd-nspawn](https://www.freedesktop.org/software/systemd/man/systemd-nspawn.html#--resolv-conf=).