### PR TITLE
Fix task recovery issues and stop all test containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
   - Ensure all test containers are properly stopped.
+  - Fixed a bug which caused tasks to not be recovered on Nomad restarts (#17)
 
 ## [0.4.0] - 2020-10-03
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+  - Ensure all test containers are properly stopped.
+
 ## [0.4.0] - 2020-10-03
 ### Added
   - Support for granting additional capabilities to containers. @mateuszlewko
@@ -27,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     logs and shown in the WebUi.
   - Support for `volume_mount` stanza. Volumes are enabled by default and can be
     disabled by setting `volumes = false` inside the driver config.
+
 ## [0.2.0] - 2020-06-27
 ### Added
   - Support for downloading images via the

--- a/nspawn/driver.go
+++ b/nspawn/driver.go
@@ -258,11 +258,6 @@ func (d *Driver) RecoverTask(handle *drivers.TaskHandle) error {
 		return fmt.Errorf("failed to decode task state from handle: %v", err)
 	}
 
-	var driverConfig drivers.TaskConfig
-	if err := handle.Config.DecodeDriverConfig(&driverConfig); err != nil {
-		return fmt.Errorf("failed to decode driver config: %v", err)
-	}
-
 	plugRC, err := pstructs.ReattachConfigToGoPlugin(taskState.ReattachConfig)
 	if err != nil {
 		return fmt.Errorf("failed to build ReattachConfig from taskConfig state: %v", err)

--- a/nspawn/driver_test.go
+++ b/nspawn/driver_test.go
@@ -362,5 +362,6 @@ func TestNspawnDriver_HandlerExec(t *testing.T) {
 		t.Fatalf("expected output to contain %q but found: %q", expected, res.Stdout)
 	}
 
+	require.NoError(harness.StopTask(task.ID, 10 * time.Second, ""))
 	require.NoError(harness.DestroyTask(task.ID, true))
 }


### PR DESCRIPTION
## Do not try to recover TaskConfig

When `RecoverTask` is called we initially tried to recover the
`TaskConfig` for a given task. This was blindly copied from the
nomad-driver-skeleton project and it turns out we make no use of it at
all.

Since this also caused Issue #17, we simply get rid of it. Recovering
tasks when a Nomad client is restarted now works again.

Closes #17
## Ensure all test containers are properly stopped

The HandlerExec test was missing a task to stop the created test
container, leaving it running after all tests were completed.