### PR TITLE
Expose private_users and private_users_ownership parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,13 @@ should cover a broad range of use cases:
 * [`user_namespacing`](https://www.freedesktop.org/software/systemd/man/systemd-nspawn.html#-U) -
   (Optional) `true` (default) or `false`. Enable user namespacing features
   inside the container.
+* [`private_users`](https://www.freedesktop.org/software/systemd/man/systemd-nspawn.html#--private-users=) -
+  (Optional). Controls how user namespacing is enabled. For this option to take
+  effect, `user_namespacing` needs to be set to `true`.
+* [`private_users_ownership`](https://www.freedesktop.org/software/systemd/man/systemd-nspawn.html#--private-users-ownership=) -
+  (Optional). Controls how to adjust the container image's UIDs and GIDs to
+  match the UID/GID range chosen with `private_users`. For this option to take
+  effect, `user_namespacing` needs to be set to `true`.
 * `command` - (Optional) A list of strings to pass as the used command to the
   container.
 

--- a/nspawn/driver.go
+++ b/nspawn/driver.go
@@ -80,9 +80,11 @@ var (
 			hclspec.NewAttr("user_namespacing", "bool", false),
 			hclspec.NewLiteral("true"),
 		),
-		"command": hclspec.NewAttr("command", "list(string)", false),
-		"console": hclspec.NewAttr("console", "string", false),
-		"image":   hclspec.NewAttr("image", "string", true),
+		"private_users":           hclspec.NewAttr("private_users", "string", false),
+		"private_users_ownership": hclspec.NewAttr("private_users_ownership", "string", false),
+		"command":                 hclspec.NewAttr("command", "list(string)", false),
+		"console":                 hclspec.NewAttr("console", "string", false),
+		"image":                   hclspec.NewAttr("image", "string", true),
 		"image_download": hclspec.NewBlock("image_download", false,
 			hclspec.NewObject(map[string]*hclspec.Spec{
 				"url": hclspec.NewAttr("url", "string", true),
@@ -234,7 +236,7 @@ func (d *Driver) Capabilities() (*drivers.Capabilities, error) {
 // It allows the driver to indicate its health to the client.
 // The channel returned should immediately send an initial Fingerprint,
 // then send periodic updates at an interval that is appropriate for the driver
-// until the context is canceled.	
+// until the context is canceled.
 func (d *Driver) Fingerprint(ctx context.Context) (<-chan *drivers.Fingerprint, error) {
 	ch := make(chan *drivers.Fingerprint)
 	go d.handleFingerprint(ctx, ch)

--- a/nspawn/nspawn.go
+++ b/nspawn/nspawn.go
@@ -75,16 +75,18 @@ type MachineConfig struct {
 	Port             hclutils.MapStrStr `codec:"port"`
 	Ports            []string           `codec:"ports"` // :-(
 	// Deprecated: Nomad dropped support for task network resources in 0.12
-	PortMap          hclutils.MapStrInt `codec:"port_map"`
-	ProcessTwo       bool               `codec:"process_two"`
-	Properties       hclutils.MapStrStr `codec:"properties"`
-	ReadOnly         bool               `codec:"read_only"`
-	ResolvConf       string             `codec:"resolv_conf"`
-	User             string             `codec:"user"`
-	UserNamespacing  bool               `codec:"user_namespacing"`
-	Volatile         string             `codec:"volatile"`
-	WorkingDirectory string             `codec:"working_directory"`
-	imagePath        string             `codec:"-"`
+	PortMap               hclutils.MapStrInt `codec:"port_map"`
+	PrivateUsers          string             `codec:"private_users"`
+	PrivateUsersOwnership string             `codec:"private_users_ownership"`
+	ProcessTwo            bool               `codec:"process_two"`
+	Properties            hclutils.MapStrStr `codec:"properties"`
+	ReadOnly              bool               `codec:"read_only"`
+	ResolvConf            string             `codec:"resolv_conf"`
+	User                  string             `codec:"user"`
+	UserNamespacing       bool               `codec:"user_namespacing"`
+	Volatile              string             `codec:"volatile"`
+	WorkingDirectory      string             `codec:"working_directory"`
+	imagePath             string             `codec:"-"`
 }
 
 type ImageType string
@@ -143,7 +145,14 @@ func (c *MachineConfig) ConfigArray() ([]string, error) {
 		args = append(args, "--read-only")
 	}
 	if c.UserNamespacing {
-		args = append(args, "-U")
+		if c.PrivateUsers == "" {
+			c.PrivateUsers = "pick"
+		}
+		if c.PrivateUsersOwnership == "" {
+			c.PrivateUsers = "auto"
+		}
+		args = append(args, fmt.Sprintf("--private-users=%s", c.PrivateUsers))
+		args = append(args, fmt.Sprintf("--private-users-ownership=%s", c.PrivateUsers))
 	}
 	if c.Console != "" {
 		args = append(args, fmt.Sprintf("--console=%s", c.Console))
@@ -217,14 +226,44 @@ func (c *MachineConfig) Validate() error {
 			return fmt.Errorf("invalid parameter for resolv_conf")
 		}
 	}
+	if c.PrivateUsers != "" {
+		switch c.PrivateUsers {
+		case "yes", "no", "pick", "identity":
+		default:
+			// Check for single UID
+			_, err := strconv.Atoi(c.PrivateUsers)
+			if err != nil {
+				// Check for colon separated UIDs
+				uIDs := strings.Split(c.PrivateUsers, ":")
+				if len(uIDs) != 2 {
+					return fmt.Errorf("invalid parameter for private_users")
+				}
+				_, err = strconv.Atoi(uIDs[0])
+				if err != nil {
+					return fmt.Errorf("invalid parameter for private_users")
+				}
+				_, err = strconv.Atoi(uIDs[1])
+				if err != nil {
+					return fmt.Errorf("invalid parameter for private_users")
+				}
+			}
+		}
+	}
+	if c.PrivateUsersOwnership != "" {
+		switch c.PrivateUsersOwnership {
+		case "auto", "map", "chown":
+		default:
+			return fmt.Errorf("invalid parameter for private_users_ownership")
+		}
+	}
 	if c.Boot && c.ProcessTwo {
 		return fmt.Errorf("boot and process_two may not be combined")
 	}
-	if c.Volatile != "" && c.UserNamespacing {
-		return fmt.Errorf("volatile and user_namespacing may not be combined")
+	if c.Volatile != "" && c.PrivateUsersOwnership == "chown" {
+		return fmt.Errorf("volatile and private_users_ownership=chown may not be combined")
 	}
-	if c.ReadOnly && c.UserNamespacing {
-		return fmt.Errorf("read_only and user_namespacing may not be combined")
+	if c.ReadOnly && c.PrivateUsersOwnership == "chown" {
+		return fmt.Errorf("read_only and private_users_ownership=chown may not be combined")
 	}
 	if c.WorkingDirectory != "" && !filepath.IsAbs(c.WorkingDirectory) {
 		return fmt.Errorf("working_directory is not an absolute path")


### PR DESCRIPTION
So advanced users can control how user namespacing is enabled in a
container. `user_namespacing` still has to be enabled for these options
to take effect.