### PR TITLE
fix PrivateUser being overwritten with auto

### DIFF
--- a/nspawn/nspawn.go
+++ b/nspawn/nspawn.go
@@ -158,7 +158,7 @@ func (c *MachineConfig) ConfigArray() ([]string, error) {
 			c.PrivateUsers = "pick"
 		}
 		if c.PrivateUsersOwnership == "" {
-			c.PrivateUsers = "auto"
+			c.PrivateUsersOwnership = "auto"
 		}
 		args = append(args, fmt.Sprintf("--private-users=%s", c.PrivateUsers))
 		args = append(args, fmt.Sprintf("--private-users-ownership=%s", c.PrivateUsersOwnership))


### PR DESCRIPTION
When using the PrivateUser feature of nspawn the wrong variable name resulted in the option PrivateUser being overwritten with the value of PrivateUserOwnership.