### PR TITLE
add support for using bridges

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,9 @@ should cover a broad range of use cases:
 * [`network_veth`](https://www.freedesktop.org/software/systemd/man/systemd-nspawn.html#-n) -
   (Optional) `true` (default) or `false`. Create a virtual ethernet link between
   the host and the container.
+* [`network_bridge`](https://www.freedesktop.org/software/systemd/man/systemd-nspawn.html#--network-bridge=) -
+  (Optional) Attach the virtual container interface to a host side bridge that
+  must already exist.
 * [`network_zone`](https://www.freedesktop.org/software/systemd/man/systemd-nspawn.html#--network-zone=) -
   (Optional) Start the container in the given network zone. Each container may
   only be part of one zone, but each zone may contain any number of containers.

--- a/nspawn/driver.go
+++ b/nspawn/driver.go
@@ -114,6 +114,7 @@ var (
 		"ports":             hclspec.NewAttr("ports", "list(string)", false),
 		"capability":        hclspec.NewAttr("capability", "list(string)", false),
 		"network_zone":      hclspec.NewAttr("network_zone", "string", false),
+		"network_bridge":    hclspec.NewAttr("network_bridge", "string", false),
 	})
 
 	// capabilities is returned by the Capabilities RPC and indicates what

--- a/nspawn/nspawn.go
+++ b/nspawn/nspawn.go
@@ -80,6 +80,7 @@ type MachineConfig struct {
 	NetworkNamespace string             `codec:"network_namespace"`
 	NetworkVeth      bool               `codec:"network_veth"`
 	NetworkZone      string             `codec:"network_zone"`
+	NetworkBridge    string             `codec:"network_bridge"`
 	PivotRoot        string             `codec:"pivot_root"`
 	Port             hclutils.MapStrStr `codec:"port"`
 	Ports            []string           `codec:"ports"` // :-(
@@ -204,6 +205,9 @@ func (c *MachineConfig) ConfigArray() ([]string, error) {
 	}
 	if len(c.NetworkZone) > 0 {
 		args = append(args, fmt.Sprintf("--network-zone=%s", c.NetworkZone))
+	}
+	if len(c.NetworkBridge) > 0 {
+		args = append(args, fmt.Sprintf("--network-bridge=%s", c.NetworkBridge))
 	}
 	if len(c.Command) > 0 {
 		args = append(args, c.Command...)


### PR DESCRIPTION
Instead of using network-zone, which automatically generates a bridge, network-bridge uses an already existing bridge on the host system.

I have tested it on my system with the following settings and it works.

```
cat <<EOF > /etc/systemd/network/10-swcore1.netdev
[NetDev]
Name=swcore1
Kind=bridge
EOF
cat <<EOF > /etc/systemd/network/10-swcore1.network                                                                                                                                                            [14:27:36]
[Match]
Name=swcore1

[Network]
Address=10.188.0.1/16
DHCPServer=yes
EOF
```

```
task "archlinux" {
      driver = "nspawn"
      config {
        image = "${NOMAD_TASK_NAME}-${NOMAD_ALLOC_ID}"
        image_download {
          type = "tar"
          url = "http://localhost/image.tar"
        }
        boot = true
        network_bridge = "swcore1"
        private_users = "pick"
        user_namespacing = true
      }
    }
```
